### PR TITLE
Implement zcat functionality

### DIFF
--- a/src/CatCmd.cpp
+++ b/src/CatCmd.cpp
@@ -4,6 +4,7 @@
 #include "au/AuDecoder.h"
 #include "AuRecordHandler.h"
 #include "TclapHelper.h"
+#include "Zindex.h"
 
 namespace au {
 
@@ -21,12 +22,17 @@ void usage() {
 }
 
 template<typename H>
-int doCat(const std::string &fileName, H &handler) {
+int doCat(const std::string &fileName, H &handler, bool compressed) {
   Dictionary dictionary;
   AuRecordHandler recordHandler(dictionary, handler);
-  FileByteSourceImpl source(fileName, false);
+  std::unique_ptr<AuByteSource> source;
+  if (compressed) {
+    source = std::make_unique<ZipByteSource>(fileName, std::nullopt);
+  } else {
+    source = std::make_unique<FileByteSourceImpl>(fileName, false);
+  }
   try {
-    RecordParser<AuRecordHandler<H>>(source, recordHandler).parseStream();
+    RecordParser<AuRecordHandler<H>>(*source, recordHandler).parseStream();
   } catch (const std::exception &e) {
     std::cerr << e.what() << " while processing " << fileName << "\n";
     return 1;
@@ -34,21 +40,19 @@ int doCat(const std::string &fileName, H &handler) {
   return 0;
 }
 
-int catFile(const std::string &fileName, bool encodeOutput) {
+int catFile(const std::string &fileName, bool encodeOutput, bool compressed) {
   if (encodeOutput) {
     AuOutputHandler handler(
         AU_STR("Re-encoded by au from original au file "
                 << (fileName == "-" ? "<stdin>" : fileName)));
-    return doCat(fileName, handler);
+    return doCat(fileName, handler, compressed);
   } else {
     JsonOutputHandler handler;
-    return doCat(fileName, handler);
+    return doCat(fileName, handler, compressed);
   }
 }
 
-}
-
-int cat(int argc, const char * const *argv) {
+int catCmd(int argc, const char * const *argv, bool compressed) {
   TclapHelper tclap(usage);
 
   TCLAP::UnlabeledMultiArg<std::string> fileNames(
@@ -62,11 +66,21 @@ int cat(int argc, const char * const *argv) {
   if (fileNames.isSet()) inputFiles = fileNames.getValue();
 
   for (const auto &f : inputFiles) {
-    auto result = catFile(f, encode.isSet());
+    auto result = catFile(f, encode.isSet(), compressed);
     if (result) return result;
   }
 
   return 0;
+}
+
+}
+
+int cat(int argc, const char * const *argv) {
+  return catCmd(argc, argv, false);
+}
+
+int zcat(int argc, const char * const *argv) {
+  return catCmd(argc, argv, true);
 }
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@ int help(int, char **) {
   usage(std::cout);
   std::cout << "\nCommands:\n"
     << "   cat      Decode listed files to stdout (alias au2json)\n"
+    << "   zcat     cat in gzipped file\n"
     << "   tail     Decode and/or follow file\n"
     << "   grep     Find records matching pattern\n"
     << "   zgrep    grep in gzipped file\n"
@@ -55,6 +56,7 @@ int main(int argc, char **argv) {
   commands["stats"] = au::stats;
   commands["zindex"] = au::zindex;
   commands["zgrep"] = au::zgrep;
+  commands["zcat"] = au::zcat;
 
   std::string cmd(argv[1]);
   auto it = commands.find(cmd);

--- a/src/main.h
+++ b/src/main.h
@@ -8,6 +8,7 @@ int grep(int argc, const char * const *argv);
 int zgrep(int argc, const char * const *argv);
 int tail(int argc, const char * const *argv);
 int cat(int argc, const char * const *argv);
+int zcat(int argc, const char * const *argv);
 int zindex(int argc, const char * const *argv);
 
 }


### PR DESCRIPTION
If the au file is compressed, and you just want to cat it, now you can
just "au zcat file.au.gz" instead of the verbose
"zcat file.au.gz | au cat"