### PR TITLE
Fix uninitialized variable

### DIFF
--- a/src/au/helpers/KeyValueHandler.h
+++ b/src/au/helpers/KeyValueHandler.h
@@ -35,7 +35,7 @@ struct KeyValueHandler : public au::NoopValueHandler {
   enum class Context : uint8_t { BARE, OBJECT, ARRAY };
   struct ContextMarker {
     Context context;
-    size_t counter;
+    size_t counter = 0;
     std::string parent;
     std::string key;
     ContextMarker(Context context, const std::string &parent,


### PR DESCRIPTION
- When uninitialized we would sometimes treat a key as a value and vice versa since isKey() depends on the counter parity.